### PR TITLE
Support text serializer (use 'utf8' data serializer from Cordova Advanced HTTP Plugin)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-resource/handler-cordova-advanced-http",
-  "version": "5.0.0",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ResourceHandlerCordovaAdvancedHttp.ts
+++ b/src/ResourceHandlerCordovaAdvancedHttp.ts
@@ -62,9 +62,12 @@ export class ResourceHandlerCordovaAdvancedHttp extends ResourceHandler {
       case ResourceRequestBodyType.FORM_DATA:
         this.http.setDataSerializer('urlencoded');
         break;
+      case ResourceRequestBodyType.TEXT:
+        this.http.setDataSerializer('utf8');
+        break;
 
       default:
-        return this.createErrorResponse('Supported only json or FormData types');
+        return this.createErrorResponse('Supported only json, FormData or text types');
     }
 
     let methodName: string = null;


### PR DESCRIPTION
Cordova Advanced HTTP Plugin introduced new serializer in version 1.10.0 which can be used for sending plain  UTF-8 encoded text content in HTTP requests.

From cordova plugin change log:
1.10.0 Feature #34: add new serializer "utf8" sending utf-8 encoded plain text (thanks robertocapuano)

Add mapping from `ResourceRequestBodyType.TEXT` to Cordova Advanced HTTP Plugin `utf8` text serializer in resource handler.
