### PR TITLE
Catch HTTP plugin exceptions during http[method] call

### DIFF
--- a/src/ResourceHandlerCordovaAdvancedHttp.ts
+++ b/src/ResourceHandlerCordovaAdvancedHttp.ts
@@ -115,7 +115,12 @@ export class ResourceHandlerCordovaAdvancedHttp extends ResourceHandler {
 
 
     const promise = new Promise((resolve, reject) => {
-      this.http[methodName](url, second, req.headers, resolve, reject);
+      try {
+        this.http[methodName](url, second, req.headers, resolve, reject);
+      } catch (e) {
+        console.error(`Http plugin call failed with: ${e.message}`, e);
+        reject({status: -1, headers: [{ error: e.message }]});
+      }
     })
       .catch((resp: any) => this.createResponse(resp, req, true))
       .then((resp: any) => this.createResponse(resp, req));


### PR DESCRIPTION
Cordova Advanced HTTP Plugin is quite restrictive with regards to resource configuration (i.e. only objects with strings are allowed as parameters, etc.) and a lot of sanity checks are performed in the plugin Javascript code. A Javascript exception is thrown in `http[method]` function call if resource method definition does not follow the plugin requirements. These exceptions are not handled by the resource handler and the exact cause for the error is lost in the rejected promise chain, making porting of existing ngx-resource/core apps from HttpClient to Cordova HTTP plugin quite painful.

This pull request wraps `http[method]` plugin call in a try/catch block and forwards the exception to promise rejection handler. Error is also logged in the console.

As a side note - the proposed solution is  "hackish" at best - as promise rejection handler expects `IResourceResponse` typed argument (w/ attributes: status, body, headers), it is currently impossible to  forward plugin error message to the rejection handler without breaking the type-safety or (ab)using body or header attributes for storing the error message. An alternative would be extending `IResourceResponse` from `resource-core` with additional attributes or redesigning the promise rejection handling completely. As this is much riskier, I'll leave it to the package maintainer to decide how (and if) to implement this and/or accept the pull request. IMHO, basic try/catch with console logging would be nice, though, as the Cordova HTTP plugin error message contains important error information.